### PR TITLE
Correct units for IMU_v2

### DIFF
--- a/src/tinkerforge_sensors_core.cpp
+++ b/src/tinkerforge_sensors_core.cpp
@@ -192,10 +192,10 @@ void TinkerforgeSensors::publishImuMessage(SensorDevice *sensor)
     else if (sensor->getType() == IMU_V2_DEVICE_IDENTIFIER)
     {
       imu_v2_get_quaternion((IMUV2*)sensor->getDev(), &ix, &iy, &iz, &iw);
-      x = ix / 16383.0;
-      y = iy / 16383.0;
-      z = iz / 16383.0;
-      w = iw / 16383.0;
+      x = float(ix) / 16383.0;
+      y = float(iy) / 16383.0;
+      z = float(iz) / 16383.0;
+      w = float(iw) / 16383.0;
 
       imu_v2_get_linear_acceleration((IMUV2*)sensor->getDev(), &acc_x, &acc_y, &acc_z);
       imu_v2_get_angular_velocity((IMUV2*)sensor->getDev(), &ang_x, &ang_y, &ang_z);
@@ -209,10 +209,10 @@ void TinkerforgeSensors::publishImuMessage(SensorDevice *sensor)
       f_acc_y = float(acc_y) / 100.0;
       f_acc_z = float(acc_z) / 100.0;
       
-      imu_msg.orientation.x = x;
-      imu_msg.orientation.y = y;
-      imu_msg.orientation.z = z;
-      imu_msg.orientation.w = w;
+      imu_msg.orientation.x = y;
+      imu_msg.orientation.y = z;
+      imu_msg.orientation.z = w;
+      imu_msg.orientation.w = x;
 
     }
     else

--- a/src/tinkerforge_sensors_core.cpp
+++ b/src/tinkerforge_sensors_core.cpp
@@ -209,10 +209,10 @@ void TinkerforgeSensors::publishImuMessage(SensorDevice *sensor)
       f_acc_y = float(acc_y) / 100.0;
       f_acc_z = float(acc_z) / 100.0;
       
-      imu_msg.orientation.x = w;
-      imu_msg.orientation.y = z;
-      imu_msg.orientation.z = y;
-      imu_msg.orientation.w = x;
+      imu_msg.orientation.x = x;
+      imu_msg.orientation.y = y;
+      imu_msg.orientation.z = z;
+      imu_msg.orientation.w = w;
 
     }
     else

--- a/src/tinkerforge_sensors_core.cpp
+++ b/src/tinkerforge_sensors_core.cpp
@@ -149,6 +149,8 @@ void TinkerforgeSensors::publishImuMessage(SensorDevice *sensor)
   int16_t ang_x, ang_y, ang_z;
   int16_t temp;
   float x = 0.0, y = 0.0, z = 0.0, w = 0.0;
+  float f_acc_x = 0.0, f_acc_y = 0.0, f_acc_z = 0.0;
+  float f_ang_x = 0.0, f_ang_y = 0.0, f_ang_z = 0.0;
   int16_t ix = 0, iy = 0, iz = 0, iw = 0;
   ros::Time current_time = ros::Time::now();
   tf::TransformBroadcaster tf_broadcaster;
@@ -172,13 +174,20 @@ void TinkerforgeSensors::publishImuMessage(SensorDevice *sensor)
       imu_get_all_data((IMU*)sensor->getDev(), &acc_x, &acc_y, &acc_z, &mag_x, &mag_y,
         &mag_z, &ang_x, &ang_y, &ang_z, &temp);
 
-      ang_x = ang_x / 14.375;
-      ang_y = ang_y / 14.375;
-      ang_z = ang_z / 14.375;
+      f_ang_x = float(ang_x) / 14.375;
+      f_ang_y = float(ang_y) / 14.375;
+      f_ang_z = float(ang_z) / 14.375;
 
-      acc_x = (acc_x/1000.0)*9.80605;
-      acc_y = (acc_y/1000.0)*9.80605;
-      acc_z = (acc_z/1000.0)*9.80605;
+      // acceleration from mG to m/s²
+      f_acc_x = (float(acc_x)/1000.0)*9.80605;
+      f_acc_y = (float(acc_y)/1000.0)*9.80605;
+      f_acc_z = (float(acc_z)/1000.0)*9.80605;
+      
+      imu_msg.orientation.x = w;
+      imu_msg.orientation.y = z*-1;
+      imu_msg.orientation.z = y;
+      imu_msg.orientation.w = x*-1;
+
     }
     else if (sensor->getType() == IMU_V2_DEVICE_IDENTIFIER)
     {
@@ -191,13 +200,20 @@ void TinkerforgeSensors::publishImuMessage(SensorDevice *sensor)
       imu_v2_get_linear_acceleration((IMUV2*)sensor->getDev(), &acc_x, &acc_y, &acc_z);
       imu_v2_get_angular_velocity((IMUV2*)sensor->getDev(), &ang_x, &ang_y, &ang_z);
 
-      ang_x = ang_x * 16;
-      ang_y = ang_y * 16;
-      ang_z = ang_z * 16;
+      f_ang_x = float(ang_x) / 16.0;
+      f_ang_y = float(ang_y) / 16.0;
+      f_ang_z = float(ang_z) / 16.0;
 
-      acc_x = acc_x * 100;
-      acc_y = acc_y * 100;
-      acc_z = acc_z * 100;
+      // acceleration from 0.01*m/s^2 to m/s^2
+      f_acc_x = float(acc_x) / 100.0;
+      f_acc_y = float(acc_y) / 100.0;
+      f_acc_z = float(acc_z) / 100.0;
+      
+      imu_msg.orientation.x = w;
+      imu_msg.orientation.y = z;
+      imu_msg.orientation.z = y;
+      imu_msg.orientation.w = x;
+
     }
     else
     {
@@ -209,12 +225,6 @@ void TinkerforgeSensors::publishImuMessage(SensorDevice *sensor)
     imu_msg.header.stamp = current_time;
     imu_msg.header.frame_id = sensor->getFrame();
 
-    //TODO adapt values for IMU v2
-    imu_msg.orientation.x = w;
-    imu_msg.orientation.y = z*-1;
-    imu_msg.orientation.z = y;
-    imu_msg.orientation.w = x*-1;
-
     // orientation_covariance
     boost::array<const double, 9> oc =
       { 0.1, 0.1, 0.1,
@@ -224,9 +234,9 @@ void TinkerforgeSensors::publishImuMessage(SensorDevice *sensor)
     imu_msg.orientation_covariance = oc;
 
     // velocity from °/14.375 to rad/s
-    imu_msg.angular_velocity.x = deg2rad(ang_x);
-    imu_msg.angular_velocity.y = deg2rad(ang_y);
-    imu_msg.angular_velocity.z = deg2rad(ang_z);
+    imu_msg.angular_velocity.x = deg2rad(f_ang_x);
+    imu_msg.angular_velocity.y = deg2rad(f_ang_y);
+    imu_msg.angular_velocity.z = deg2rad(f_ang_z);
 
     // velocity_covariance
     boost::array<const double, 9> vc =
@@ -235,10 +245,9 @@ void TinkerforgeSensors::publishImuMessage(SensorDevice *sensor)
         0.1, 0.1, 0.1};
     imu_msg.angular_velocity_covariance = vc;
 
-    // acceleration from mG to m/s²
-    imu_msg.linear_acceleration.x = acc_x;
-    imu_msg.linear_acceleration.y = acc_y;
-    imu_msg.linear_acceleration.z = acc_z;
+    imu_msg.linear_acceleration.x = f_acc_x;
+    imu_msg.linear_acceleration.y = f_acc_y;
+    imu_msg.linear_acceleration.z = f_acc_z;
 
     // linear_acceleration_covariance
     boost::array<const double, 9> lac =


### PR DESCRIPTION
Modified unit conversion for quaternion, linear acceleration, and angular velocity for the IMU v2.

- Quaternion: Previously the x, y, z and w axes were swapped around, and x and z were inverted. I believe this is due to some idiosyncrasy of the IMU_v1. However, these corrections shouldn't be applied to output from the IMU_v2.

- Linear Acceleration: Previously the linear acceleration values were multiplied by 100 instead of divided by 100 to convert them from (1/100) m/s^2, resulting in abnormally large values. Now they are converted to floats and divided by 100.

- Angular Velocity: Previously the angular velocity values were multiplied by 16 instead of divided. This resulted in abnormally large values. Now they are converted to floats and divided by 16.

- IMU_v1 Angular velocity: Previously the units of these values were converted by using integer division, which causes data loss due to rounding errors. Now they are converted to floats first.

I've tested this on a few Tinkerforge IMU_v2 units, and the results are now in line with the output from the Tinkerforge Brick viewer program.